### PR TITLE
Add basic application scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+venv/
+__pycache__/
+*.pyc
+app.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # 2025_BASIC
+
+This repository contains a minimal GUI demo project. The code is split into
+three packages under `src/`:
+
+- `gui` – Tkinter-based application window and plugin loader.
+- `database` – SQLAlchemy setup for an SQLite database.
+- `auth` – simple user management utilities.
+
+Run the app with:
+
+```bash
+python main.py
+```
+
+## Further Suggestions for Beginners
+
+- Explore how plugins are loaded in `src/gui/app.py` and try creating your own
+  modules inside the `plugins/` directory.
+- The current authentication logic uses the Werkzeug password utilities. For a
+  real project, consider more advanced user management and proper error
+  handling.
+- Check out SQLAlchemy's documentation to learn how to create models and query
+  data effectively.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,12 @@
+from src.gui import Application
+from src.database.connection import init_db
+
+
+def main() -> None:
+    init_db()
+    app = Application()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+PyQt5>=5.15
+SQLAlchemy>=2.0
+pluggy>=1.3
+Werkzeug>=3.0

--- a/src/auth/__init__.py
+++ b/src/auth/__init__.py
@@ -1,0 +1,3 @@
+from .login import create_user, authenticate
+
+__all__ = ["create_user", "authenticate"]

--- a/src/auth/login.py
+++ b/src/auth/login.py
@@ -1,0 +1,17 @@
+from sqlalchemy.orm import Session
+from werkzeug.security import check_password_hash, generate_password_hash
+from ..database.models import User
+
+
+def create_user(session: Session, username: str, password: str) -> User:
+    user = User(username=username, password=generate_password_hash(password))
+    session.add(user)
+    session.commit()
+    return user
+
+
+def authenticate(session: Session, username: str, password: str) -> bool:
+    user = session.query(User).filter_by(username=username).first()
+    if not user:
+        return False
+    return check_password_hash(user.password, password)

--- a/src/database/__init__.py
+++ b/src/database/__init__.py
@@ -1,0 +1,4 @@
+from .connection import ENGINE, SessionLocal, Base, init_db
+from .models import User
+
+__all__ = ["ENGINE", "SessionLocal", "Base", "init_db", "User"]

--- a/src/database/connection.py
+++ b/src/database/connection.py
@@ -1,0 +1,11 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+ENGINE = create_engine("sqlite:///app.db", echo=False)
+SessionLocal = sessionmaker(bind=ENGINE)
+Base = declarative_base()
+
+
+def init_db() -> None:
+    """Create database tables."""
+    Base.metadata.create_all(ENGINE)

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -1,0 +1,10 @@
+from sqlalchemy import Column, Integer, String
+from .connection import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True)
+    username = Column(String, unique=True, nullable=False)
+    password = Column(String, nullable=False)

--- a/src/gui/__init__.py
+++ b/src/gui/__init__.py
@@ -1,0 +1,3 @@
+from .app import Application
+
+__all__ = ["Application"]

--- a/src/gui/app.py
+++ b/src/gui/app.py
@@ -1,0 +1,36 @@
+import importlib
+import pkgutil
+from pathlib import Path
+import tkinter as tk
+import pluggy
+
+
+class GUIPluginSpec:
+    def start(self, app: tk.Tk) -> None:
+        """Optional hook called after plugins are loaded."""
+
+
+class Application(tk.Tk):
+    """Main application window with basic plugin loader."""
+
+    def __init__(self, plugins_path: str | None = None):
+        super().__init__()
+        self.title("Demo App")
+        self.geometry("300x200")
+        self.plugins_path = Path(plugins_path or "plugins")
+        self.plugin_manager = pluggy.PluginManager("guiapp")
+        self.plugin_manager.add_hookspecs(GUIPluginSpec)
+        self._load_plugins()
+        self.plugin_manager.hook.start(app=self)
+
+    def _load_plugins(self) -> None:
+        """Load plugins as Python modules from the plugins directory."""
+        if not self.plugins_path.exists():
+            return
+        for module_info in pkgutil.iter_modules([str(self.plugins_path)]):
+            module_name = module_info.name
+            try:
+                mod = importlib.import_module(f"plugins.{module_name}")
+                self.plugin_manager.register(mod)
+            except Exception as exc:  # pragma: no cover - simple demo
+                print(f"Failed to load plugin {module_name}: {exc}")


### PR DESCRIPTION
## Summary
- add GUI, database, and auth packages
- wire them together with a Tkinter demo app
- provide requirements listing PyQt5, SQLAlchemy, pluggy, and Werkzeug
- document usage and beginner tips
- ignore common artifacts

## Testing
- `python3 -m py_compile $(find src -name '*.py') main.py`

------
https://chatgpt.com/codex/tasks/task_e_6860172f2acc8325bbe23c3790820042