### PR TITLE
Add plugin example and update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-cat > .gitignore << 'EOF'
 # Python-Virtual Environment
 venv/
 
@@ -19,4 +18,3 @@ app.db
 # Tests-Output, Coverage, etc.
 .coverage
 htmlcov/
-EOF

--- a/README.md
+++ b/README.md
@@ -32,3 +32,6 @@ pytest -q
 Plugin modules placed under `plugins/` are loaded automatically at startup. This
 provides an easy way to extend the GUI without modifying existing code.
 
+An example plugin is included in `plugins/example.py`. It demonstrates how to
+add items to the interface after the main window has been created.
+

--- a/info-todo.txt
+++ b/info-todo.txt
@@ -1,13 +1,13 @@
 # Project TODO
 
 ## Upcoming tasks
-- Implement plugin examples
 - Write automated tests
 - Improve folder management
 
 ## Completed tasks
 - Set up basic project structure
 - Created dashboard with left and right sidebars
+- Added example plugin under plugins/example.py
 - Integrated login dialog and automatic user directory creation
 
 ## Finished components

--- a/plugins/example.py
+++ b/plugins/example.py
@@ -1,0 +1,12 @@
+"""Example plugin that adds an item to the left sidebar."""
+from PyQt5 import QtWidgets
+
+
+def init(app_window):
+    """Simple hook that adds an item to the left dock list."""
+    for dock in app_window.findChildren(QtWidgets.QDockWidget):
+        if dock.windowTitle() == "Links":
+            list_widget = dock.widget()
+            list_widget.addItem("Example Plugin")
+            break
+

--- a/src/gui/app.py
+++ b/src/gui/app.py
@@ -97,7 +97,9 @@ def run():
 
     window.show()
 
-    # Load plugins (if any)
-    load_plugins()
+    # Load plugins (if any) and initialize them with the main window
+    for plugin in load_plugins():
+        if hasattr(plugin, "init"):
+            plugin.init(window)
 
     return app.exec_()

--- a/weitere-Implementierungen-info.txt
+++ b/weitere-Implementierungen-info.txt
@@ -2,7 +2,7 @@
 #
 Projektzusammenfassung: „Benutzerbasiertes Ordner- und Struktur-Tool mit Debug-Engine“
 🔧 Systemüberblick
-Ein modulares, offlinefähiges Tool für Linux mit GUI (PyQt6), das:
+Ein modulares, offlinefähiges Tool für Linux mit GUI (PyQt5), das:
 
 Benutzer mit 4-stelligem PIN verwaltet
 


### PR DESCRIPTION
## Summary
- add a small example plugin under `plugins/example.py`
- initialize plugins in the GUI
- document plugin example in README
- update info-todo with completed plugin task
- fix PyQt version mention in `weitere-Implementierungen-info.txt`
- clean up `.gitignore`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860a92932f883258673a290677eab64