### PR TITLE
Fix main entry path

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,12 @@
+"""Main entry point for the 2025_BASIC application."""
+
+import sys
+from pathlib import Path
+
+SRC_PATH = Path(__file__).resolve().parent / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
 from gui.app import run
 
 if __name__ == "__main__":


### PR DESCRIPTION
Issue #1

Ensure Python can locate the `src` package when running `main.py`. The entry
point now inserts `src` into `sys.path` before importing the GUI module.

Test status: ✅ `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860c76419dc8325ae99deaaf2ebbf38