### PR TITLE
docs: streamline info docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
 # 2025_BASIC
 
-This project provides a simple GUI application template with an SQLite database
-and user authentication. The code is located under the `src/` directory. When
-starting the app you will be asked to log in. On successful login a directory
-`users/<name>` is created automatically for storing user files.
+This project provides a simple GUI application template with an SQLite database and user authentication. The code lives under the `src/` directory. When starting the app you will be asked to log in. On successful login a directory `users/<name>` is created automatically for storing user files.
 
-The main window presents a basic dashboard with collapsible sidebars on the left
-and right. The structure is modular so that plugins placed in a `plugins/`
-package can extend the interface.
+The main window presents a basic dashboard with collapsible sidebars on the left and right. The structure is modular so that plugins placed in a `plugins/` package can extend the interface.
+
+## Setup
+Install the dependencies once with:
+
+```bash
+pip install -r requirements.txt
+```
 
 ## Packages
-
-- **gui** – contains the main application window and a basic plugin loader using `importlib`.
-- **database** – handles SQLite connections and initial schema creation.
-- **auth** – simple user login utilities.
+- **gui** – main application window and plugin loader
+- **database** – SQLite connection and initial schema
+- **auth** – user login utilities
 
 Development tasks are tracked in `info-todo.txt`.
 
@@ -29,6 +30,4 @@ To run tests (once they are added), execute:
 pytest -q
 ```
 
-Plugin modules placed under `plugins/` are loaded automatically at startup. This
-provides an easy way to extend the GUI without modifying existing code.
-
+Plugin modules placed under `plugins/` are loaded automatically at startup. This provides an easy way to extend the GUI without modifying existing code.

--- a/info-todo.txt
+++ b/info-todo.txt
@@ -1,16 +1,18 @@
 # Project TODO
 
 ## Upcoming tasks
-- Implement plugin examples
-- Write automated tests
-- Improve folder management
+- Implement plugin examples under `plugins/`
+- Write automated tests with `pytest`
+- Improve folder management for user files
 
 ## Completed tasks
-- Set up basic project structure
-- Created dashboard with left and right sidebars
-- Integrated login dialog and automatic user directory creation
-
-## Finished components
-- GUI framework using PyQt5
+- Basic project structure with PyQt5 GUI
+- Dashboard with left and right sidebars
+- Login dialog with automatic user directory creation
 - SQLite database initialization
-- Login dialog and folder creation
+
+## Helpful commands
+- Start the app: `python main.py`
+- Run tests: `pytest -q`
+- Install requirements: `pip install -r requirements.txt`
+- Format code: `black .` and `isort .`

--- a/weitere-Implementierungen-info.txt
+++ b/weitere-Implementierungen-info.txt
@@ -1,118 +1,53 @@
-# weitere zukünftige Implementierungen 
-#
-Projektzusammenfassung: „Benutzerbasiertes Ordner- und Struktur-Tool mit Debug-Engine“
-🔧 Systemüberblick
-Ein modulares, offlinefähiges Tool für Linux mit GUI (PyQt6), das:
+# Weitere zukünftige Implementierungen
 
-Benutzer mit 4-stelligem PIN verwaltet
+Projektzusammenfassung: "Benutzerbasiertes Ordner- und Struktur-Tool mit Debug-Engine"
 
-Für jeden Benutzer eine deutsche Standard-Ordnerstruktur anlegt
+## Systemüberblick
+Ein modulares, offlinefähiges Tool für Linux mit GUI (PyQt6), das
+Benutzer mit 4-stelligem PIN verwaltet, für jeden Benutzer eine deutsche
+Standard-Ordnerstruktur anlegt und einen Debug-Modus mit Auto-Repair,
+Tests und detaillierten Logs bereitstellt. Einstellungen werden
+persistent gespeichert und durch Plug-ins erweiterbar.
 
-Debug-Modus mit Auto-Repair, Tests und detaillierten Logs unterstützt
-
-Plug-in-fähig ist
-
-Einstellungen persistent speichert
-
-Datenbankintegration zur Verwaltung benutzerdefinierter Inhalte (z. B. Einträge mit Titel/Text)
-
-📂 Aktuelle Verzeichnisstruktur
-bash
-Kopieren
-Bearbeiten
-/config/                   # Einstellungen & DB-Datei
+## Aktuelle Verzeichnisstruktur
+```
+/config/                   # Einstellungen & Datenbank
     nutzer.db
     einstellungen.json
-
 /nutzerbereiche/          # Benutzerverzeichnisse
     <benutzername>/
-
-/logs/                    # Reparatur- & Debug-Protokolle
+/logs/                    # Reparatur- und Debug-Protokolle
     auto_repair.log
     debug_details.log
-
 /modules/                 # Zentrale Logikmodule
     db_controller.py
-
-/plugins/                 # Plug-in-System vorbereitet
+/plugins/                 # Plug-in-System
     <plugin_name>/
         plugin.json
         plugin_main.py
-
-/tests/                   # Geplant: strukturiert nach Szenarien & Zeit
-    ...
-
-/update/                  # Update-Logik vorbereitet
-
+/tests/                   # Geplante Tests
+/update/                  # Update-Logik
 /main.py                  # Einstiegspunkt
-/plugin_loader.py         # Dynamisches Laden externer Module
+/plugin_loader.py         # Lädt Plug-ins
 /settings_tab.py          # GUI-Modul für Einstellungen
-✅ Implementierte Funktionen
-Wizard (Login-GUI):
+```
 
-Benutzeranmeldung per PIN
+## Implementierte Funktionen
+- Wizard (Login-GUI) mit PIN-Anmeldung
+- Persistenter Debug-Modus mit Auto-Repair und Log-Ausgabe
+- Getrennte Eingabe- und Systemfehlerbehandlung
+- Einstellungsbereich für Sprache und Pfadoptionen
+- Plug-in-System mit `plugin.json` und `plugin_main.py`
+- Datenbankmodul `db_controller.py` speichert Benutzer und Inhalte
 
-Debug-Modus aktivierbar (persistent)
+## Nächste Schritte
+- Einstellungs-GUI um Debug-Testbereiche erweitern
+- Inhaltstabelle in der Datenbank ausbauen
+- Plugin-Demo entwickeln (z.B. zusätzlicher Export-Tab)
+- Tests in `tests/` mit Szenarien-IDs erstellen
 
-Eingabemaske visuell eingerahmt („Anmeldung“)
-
-Optisch konsistent (LOGIN-Button hervorgehoben)
-
-Debug-Modus:
-
-Führt Auto-Repair von Ordnerstrukturen durch
-
-Schreibt in debug_details.log mit Lösungshinweisen
-
-Trennung von Eingabefehlern und Systemdefekten
-
-In den Einstellungen: zwei Blöcke für Systemtests (oben) und Hilfsaktionen (unten)
-
-Benutzer-Datenbank:
-
-Modul: db_controller.py
-
-Speichert: Benutzer + PIN
-
-Inhalte: Tabelle eintraege mit titel, kurztext, volltext
-
-Optional: zusätzliche Felder durch zusatzfelder.json erweiterbar
-
-Einstellungen (GUI-Tab):
-
-Debug-Modus (an/aus)
-
-Sprache (Deutsch/Englisch)
-
-Nutzerbereich-Pfad konfigurierbar
-
-Speichert persistente Optionen
-
-Plug-in-System:
-
-Lädt dynamisch Plug-ins aus plugins/
-
-Definition via plugin.json, Logik via plugin_main.py
-
-📌 Nächste Schritte (für Weiterentwicklung)
-Einstellungs-GUI mit Debug-Testbereichen fertigstellen (Widgets für Auto-Tests und Helfer)
-
-Datenbankmodul um Inhalte-Tabelle erweitern (Einträge, optional zusätzliche Felder)
-
-Hauptmodul mit Benutzerkontext starten (nach Login geerbter Zustand)
-
-Plugin-Demo entwickeln (z. B. Anzeige-Tab oder zusätzlicher Export)
-
-Tests einbauen und kapseln in /tests/ mit Szenarien-IDs
-
-🔁 Letzte Iterationslogeinträge
-„Debug-Modus aktiviert, Auto-Repair eingebunden“
-
-„Plugin-Loader erstellt“
-
-„Einstellungs-Tab vorbereitet mit Sprache, Debug, Pfad“
-
-„Login-GUI optisch eingerahmt, Eingabefelder getrennt von persistenter Auswahl“
-
-„db_controller ausgelagert, eintraege-Tabelle definiert (Basis)“
-
+## Nützliche Befehle
+- Anwendung starten: `python main.py`
+- Abhängigkeiten installieren: `pip install -r requirements.txt`
+- Tests ausführen: `pytest -q`
+- Code formatieren: `black .` und `isort .`


### PR DESCRIPTION
## Summary
- simplify and clean up info files
- add setup instructions in `README.md`
- include helpful command snippets for beginners

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860cd7fe76083259aeebe71d76ca2ca