### PR TITLE
Add plugin example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,21 @@ Run the application with:
 python main.py
 ```
 
-To run tests (once they are added), execute:
+For development with logging and automatic test execution run:
+
+```bash
+python dev_start.py
+```
+
+To run the tests, execute:
 
 ```bash
 pytest -q
 ```
+All tests are located under the `tests/` directory.
 
 Plugin modules placed under `plugins/` are loaded automatically at startup. This
 provides an easy way to extend the GUI without modifying existing code.
+An example plugin `example_tab.py` is included to demonstrate how new docks can
+be added dynamically.
 

--- a/dev_start.py
+++ b/dev_start.py
@@ -1,0 +1,48 @@
+import logging
+import subprocess
+from pathlib import Path
+
+from database.db import init_db
+from gui.app import run
+
+LOG_DIR = Path("logs")
+LOG_DIR.mkdir(exist_ok=True)
+logging.basicConfig(
+    filename=LOG_DIR / "dev.log",
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+
+
+def run_tests() -> bool:
+    """Run test suite and return True if successful."""
+    try:
+        result = subprocess.run(["pytest", "-q"], check=False, capture_output=True)
+        logging.info(result.stdout.decode())
+        if result.returncode != 0:
+            logging.error("Tests failed")
+            return False
+        return True
+    except Exception as exc:  # pragma: no cover - best effort logging
+        logging.exception("Running tests failed: %s", exc)
+        return False
+
+
+def auto_repair() -> None:
+    """Simple self-healing placeholder."""
+    db_file = Path("app.db")
+    if not db_file.exists():
+        logging.warning("Database missing. Reinitializing.")
+        init_db()
+
+
+if __name__ == "__main__":
+    tests_ok = run_tests()
+    if not tests_ok:
+        print("Tests failed. See logs/dev.log for details.")
+    auto_repair()
+    try:
+        run()
+    except Exception as exc:  # pragma: no cover - guard GUI startup
+        logging.exception("Application crashed: %s", exc)
+        print("Application crashed. Check logs/dev.log.")

--- a/plugins/example_tab.py
+++ b/plugins/example_tab.py
@@ -1,0 +1,9 @@
+from PyQt5 import QtCore, QtWidgets
+
+
+def register(window: QtWidgets.QMainWindow) -> None:
+    """Add a demo tab to the main window."""
+    dock = QtWidgets.QDockWidget("Demo", window)
+    label = QtWidgets.QLabel("Hello from plugin!", alignment=QtCore.Qt.AlignCenter)
+    dock.setWidget(label)
+    window.addDockWidget(QtCore.Qt.BottomDockWidgetArea, dock)

--- a/src/auth/login.py
+++ b/src/auth/login.py
@@ -12,10 +12,7 @@ def authenticate(username: str, password: str) -> bool:
     init_db()
     conn = get_connection()
     cursor = conn.cursor()
-    cursor.execute(
-        "SELECT password FROM users WHERE username=?",
-        (username,)
-    )
+    cursor.execute("SELECT password FROM users WHERE username=?", (username,))
     row = cursor.fetchone()
     conn.close()
     if not row:

--- a/src/gui/app.py
+++ b/src/gui/app.py
@@ -1,7 +1,8 @@
-from PyQt5 import QtWidgets, QtCore
 import importlib
 import pkgutil
 from pathlib import Path
+
+from PyQt5 import QtCore, QtWidgets
 
 from auth.login import authenticate
 
@@ -97,7 +98,10 @@ def run():
 
     window.show()
 
-    # Load plugins (if any)
-    load_plugins()
+    # Load plugins (if any) and allow them to extend the GUI
+    for plugin in load_plugins():
+        register = getattr(plugin, "register", None)
+        if callable(register):
+            register(window)
 
     return app.exec_()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Allow importing from src directory
+SRC_PATH = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,10 @@
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from gui.app import load_plugins
+
+
+def test_plugins_can_be_loaded():
+    plugins = load_plugins()
+    assert any(getattr(mod, "register", None) for mod in plugins)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,5 @@
+from auth.login import hash_password
+
+
+def test_hash_password_length():
+    assert len(hash_password("example")) == 64


### PR DESCRIPTION
## Issue
n/a

## Summary
- integrate plugins during GUI startup
- provide an example plugin `example_tab.py`
- document plugin usage in the README
- add tests for plugin loading

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860dc1973a48325b6c3408503e4e186