### PR TITLE
Implement demo plugin and user folders

### DIFF
--- a/plugins/demo_data.py
+++ b/plugins/demo_data.py
@@ -1,0 +1,28 @@
+from PyQt5 import QtWidgets
+
+from database.db import get_connection
+
+
+def setup(window):
+    """Add a button to insert a demo record into the database."""
+    dashboard = window.centralWidget()
+    layout = dashboard.layout()
+    if layout is None:
+        layout = QtWidgets.QVBoxLayout(dashboard)
+        dashboard.setLayout(layout)
+
+    button = QtWidgets.QPushButton("Demo-Datensatz einfügen")
+
+    def on_click():
+        conn = get_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            "CREATE TABLE IF NOT EXISTS demo (id INTEGER PRIMARY KEY AUTOINCREMENT, info TEXT)"
+        )
+        cursor.execute("INSERT INTO demo (info) VALUES (?)", ("Beispiel",))
+        conn.commit()
+        conn.close()
+        QtWidgets.QMessageBox.information(window, "Info", "Demo-Datensatz gespeichert")
+
+    button.clicked.connect(on_click)
+    layout.addWidget(button)

--- a/src/gui/app.py
+++ b/src/gui/app.py
@@ -49,9 +49,13 @@ class LoginDialog(QtWidgets.QDialog):
 
 
 def ensure_user_folder(username: str, root: Path = Path("users")):
-    """Create a data folder for the given user if it doesn't exist."""
+    """Create a data folder for the given user with standard subfolders."""
     user_dir = root / username
     user_dir.mkdir(parents=True, exist_ok=True)
+
+    for name in ["Dokumente", "Bilder", "Projekte"]:
+        (user_dir / name).mkdir(exist_ok=True)
+
     return user_dir
 
 
@@ -99,6 +103,8 @@ def run():
     window.show()
 
     # Load plugins (if any)
-    load_plugins()
+    for plugin in load_plugins():
+        if hasattr(plugin, "setup"):
+            plugin.setup(window)
 
     return app.exec_()

--- a/tests/test_user_folders.py
+++ b/tests/test_user_folders.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+from gui.app import ensure_user_folder
+
+
+def test_standard_subfolders(tmp_path):
+    base = tmp_path / "users"
+    path = ensure_user_folder("alice", root=base)
+    assert (path / "Dokumente").exists()
+    assert (path / "Bilder").exists()
+    assert (path / "Projekte").exists()


### PR DESCRIPTION
## Summary
- create `plugins/` package with demo plugin to add DB entry
- ensure `ensure_user_folder` makes standard subfolders
- load plugins via `setup()` hook
- test creation of standard subfolders

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68616092592c832596175bb8e5c2c3ec